### PR TITLE
Add referral / reach out tab

### DIFF
--- a/src/app/_components/client/Client.tsx
+++ b/src/app/_components/client/Client.tsx
@@ -266,7 +266,7 @@ export function Client({
 									</div>
 								</TabsContent>
 							)}
-							{client.id.toString().length !== 5 && (
+							{!isShellClientId(client.id) && (
 								<TabsContent value="referral">
 									<div className="mb-6 flex min-w-full flex-col items-center gap-6">
 										<ReferralTab client={client} readOnly={readOnly} />

--- a/src/app/_components/client/Client.tsx
+++ b/src/app/_components/client/Client.tsx
@@ -32,6 +32,7 @@ import { MergeRecommendationAlert } from "./MergeRecommendationAlert";
 import { PersistentStatusAlert } from "./PersistentStatusAlert";
 import { QuestionnairesTable } from "./QuestionnairesTable";
 import { RecordsNoteEditor } from "./RecordsNoteEditor";
+import { ReferralTab } from "./ReferralTab";
 import { RelatedClients } from "./RelatedClients";
 
 const log = logger.child({ module: "Client" });
@@ -147,6 +148,7 @@ export function Client({
 								<TabsList className="w-full">
 									<TabsTrigger value="info">Info</TabsTrigger>
 									<TabsTrigger value="records">Records</TabsTrigger>
+									<TabsTrigger value="referral">Referral</TabsTrigger>
 								</TabsList>
 							)}
 
@@ -261,6 +263,13 @@ export function Client({
 											clientId={client.id}
 											readOnly={readOnly}
 										/>
+									</div>
+								</TabsContent>
+							)}
+							{client.id.toString().length !== 5 && (
+								<TabsContent value="referral">
+									<div className="mb-6 flex min-w-full flex-col items-center gap-6">
+										<ReferralTab client={client} readOnly={readOnly} />
 									</div>
 								</TabsContent>
 							)}

--- a/src/app/_components/client/Client.tsx
+++ b/src/app/_components/client/Client.tsx
@@ -269,6 +269,7 @@ export function Client({
 							{!isShellClientId(client.id) && (
 								<TabsContent value="referral">
 									<div className="mb-6 flex min-w-full flex-col items-center gap-6">
+										<ClientDetailsCard client={client} truncated />
 										<ReferralTab client={client} readOnly={readOnly} />
 									</div>
 								</TabsContent>

--- a/src/app/_components/client/Client.tsx
+++ b/src/app/_components/client/Client.tsx
@@ -14,6 +14,7 @@ import {
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { useCheckPermission } from "~/hooks/use-check-permission";
 import type { ClientColor } from "~/lib/colors";
 import { logger } from "~/lib/logger";
 import {
@@ -47,6 +48,7 @@ export function Client({
 	const router = useRouter();
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
+	const can = useCheckPermission();
 
 	const activeTab = searchParams.get("tab") ?? "info";
 
@@ -148,7 +150,10 @@ export function Client({
 								<TabsList className="w-full">
 									<TabsTrigger value="info">Info</TabsTrigger>
 									<TabsTrigger value="records">Records</TabsTrigger>
-									<TabsTrigger value="referral">Referral</TabsTrigger>
+									{/* It's fine that this doesn't stop people from just visiting the URL, we aren't hiding this for security, we're hiding it so that we don't get people confused about it existing */}
+									{can("clients:referral:tab") && (
+										<TabsTrigger value="referral">Referral</TabsTrigger>
+									)}
 								</TabsList>
 							)}
 

--- a/src/app/_components/client/DashboardStatus.tsx
+++ b/src/app/_components/client/DashboardStatus.tsx
@@ -17,6 +17,9 @@ export function DashboardStatus({ clientId }: { clientId: number }) {
 			staleTime: 60000,
 		});
 
+	const { data: needsReachOut } = api.clients.getNeedsReachOut.useQuery();
+	const { data: needsReview } = api.clients.getNeedsReview.useQuery();
+
 	if (isLoading) {
 		return <Skeleton className="h-6 w-32" />;
 	}
@@ -28,14 +31,21 @@ export function DashboardStatus({ clientId }: { clientId: number }) {
 		(m: Client) => m.id === clientId,
 	);
 
-	if (!clientOnPunch && !clientMissing) {
+	const isInReachOut = needsReachOut?.some((c) => c.id === clientId);
+	const isInReview = needsReview?.some((c) => c.id === clientId);
+
+	if (!clientOnPunch && !clientMissing && !isInReachOut && !isInReview) {
 		return null;
 	}
 
 	const matchedSections = getClientMatchedSections(
-		(clientOnPunch ?? clientMissing) as FullClientInfo | Client,
+		(clientOnPunch ?? clientMissing ?? { id: clientId }) as
+			| FullClientInfo
+			| Client,
 		dashboardData?.punchClients ?? [],
 		dashboardData?.missingClients ?? [],
+		needsReachOut ?? [],
+		needsReview ?? [],
 	);
 
 	if (matchedSections.length === 0) {

--- a/src/app/_components/client/EditAsdAdhdDialog.tsx
+++ b/src/app/_components/client/EditAsdAdhdDialog.tsx
@@ -46,9 +46,9 @@ export function EditAsdAdhdDialog({ client, setOpen }: EditAsdAdhdDialogProps) {
 		},
 	});
 
-	const updateAsdAdhd = api.google.setAsdAdhd.useMutation({
-		onSuccess: (data) => {
-			toast.success(data.message);
+	const updateAsdAdhd = api.clients.update.useMutation({
+		onSuccess: () => {
+			toast.success("ASD/ADHD status updated successfully");
 			utils.clients.getOne.invalidate();
 			setOpen(false);
 		},

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -164,10 +164,18 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 							your referral and wanted to ask you some questions to get started
 							on our process.
 						</p>
+						<p>
+							I just want to confirm you and/or your pediatrician have concerns
+							about potential{" "}
+							{asdAdhdValue
+								.replace("ASD", "autism")
+								.replace("LD", "learning disability")}
+							.
+						</p>
 						{!isAdhd && (
 							<p>
-								Has the child started school yet? Do they have an IEP or 504
-								plan?
+								Has the child been evaluated at school? Do they have an IEP or
+								504 plan?
 							</p>
 						)}
 					</div>
@@ -233,9 +241,6 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 
 					<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
 						<p>
-							I just want to confirm you have concerns about {asdAdhdValue}.
-						</p>
-						<p>
 							We would like to set you up in our Patient Portal. To do that, we
 							need to send you an email. Can I please have your email address?
 						</p>
@@ -293,20 +298,10 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 								</>
 							) : (
 								<>
-									{schoolIepStatus === "yes" && (
-										<p>
-											We will request records from the school district and then
-											be in touch to discuss next steps.
-										</p>
-									)}
-									{schoolIepStatus === "no" && (
-										<p>
-											We will send you a questionnaire through the portal soon.
-											Look for a new message, which is usually in the upper
-											right hand corner of the screen. You will also get an
-											email telling you that you have a new message.
-										</p>
-									)}
+									<p>
+										We will request records from the school district and then be
+										in touch to discuss next steps.
+									</p>
 									<p>
 										Generally, we will schedule an intake appointment via
 										Telehealth. From there, we will request approval from

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { Button } from "@ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@ui/card";
+import { Input } from "@ui/input";
+import { Label } from "@ui/label";
+import { RadioGroup, RadioGroupItem } from "@ui/radio-group";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@ui/select";
+import { Textarea } from "@ui/textarea";
+import { useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { ALLOWED_ASD_ADHD_VALUES } from "~/lib/constants";
+import type { Client } from "~/lib/models";
+import { api } from "~/trpc/react";
+
+interface ReferralTabProps {
+	client: Client;
+	readOnly?: boolean;
+}
+
+export function ReferralTab({ client, readOnly }: ReferralTabProps) {
+	const { data: session } = useSession();
+	const utils = api.useUtils();
+
+	const [schoolIepStatus, setSchoolIepStatus] = useState<string>(
+		client.referralData?.schoolIepStatus ?? "",
+	);
+	const [schoolExplanation, setMoreInfo] = useState<string>(
+		client.referralData?.schoolExplanation ?? "",
+	);
+	const [otherNotes, setOtherNotes] = useState<string>(
+		client.referralData?.otherNotes ?? "",
+	);
+	const [locationPreference, setLocationPreference] = useState<string>(
+		client.referralData?.locationPreference ?? "",
+	);
+	const [email, setEmail] = useState<string>(client.email ?? "");
+
+	useEffect(() => {
+		setSchoolIepStatus(client.referralData?.schoolIepStatus ?? "");
+		setMoreInfo(client.referralData?.schoolExplanation ?? "");
+		setOtherNotes(client.referralData?.otherNotes ?? "");
+		setLocationPreference(client.referralData?.locationPreference ?? "");
+		setEmail(client.email ?? "");
+	}, [client.referralData, client.email]);
+
+	const updateClientMutation = api.clients.update.useMutation({
+		onSuccess: () => {
+			utils.clients.getOne.invalidate({ column: "hash", value: client.hash });
+		},
+		onError: (error) => {
+			toast.error("Failed to update referral info", {
+				description: error.message,
+			});
+		},
+	});
+
+	const pushToPunchMutation = api.google.pushToPunch.useMutation({
+		onSuccess: () => {
+			toast.success("Pushed to punch list");
+			void utils.google.getClientFromPunch.invalidate(client.id.toString());
+		},
+		onError: (error) => {
+			toast.error("Failed to push to punch list", {
+				description: error.message,
+			});
+		},
+	});
+
+	const { data: punchClient, isLoading: isLoadingPunchClient } =
+		api.google.getClientFromPunch.useQuery(client.id.toString(), {
+			enabled: !!client.id,
+		});
+
+	const handleAsdAdhdChange = (value: string) => {
+		updateClientMutation.mutate({
+			clientId: client.id,
+			asdAdhd: value as (typeof ALLOWED_ASD_ADHD_VALUES)[number],
+		});
+	};
+
+	const handleReferralDataChange = (updates: {
+		schoolIepStatus?: string;
+		schoolExplanation?: string;
+		otherNotes?: string;
+		locationPreference?: string;
+	}) => {
+		const newReferralData = {
+			...client.referralData,
+			...updates,
+		};
+		updateClientMutation.mutate({
+			clientId: client.id,
+			referralData: newReferralData,
+		});
+	};
+
+	const handleEmailChange = (newEmail: string) => {
+		updateClientMutation.mutate({
+			clientId: client.id,
+			email: newEmail,
+		});
+	};
+
+	const userName = session?.user?.name?.split(" ")[0] ?? "(Your Name)";
+	const asdAdhdValue = client.asdAdhd ?? "(Diagnosis)";
+	const isAdhd = client.asdAdhd === "ADHD";
+
+	return (
+		<div className="flex flex-col gap-4">
+			<Card className="w-full">
+				<CardHeader>
+					<CardTitle>Referral Information</CardTitle>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+						<div className="space-y-2">
+							<Label htmlFor="asdAdhd">This is for</Label>
+							<Select
+								disabled={readOnly || updateClientMutation.isPending}
+								onValueChange={handleAsdAdhdChange}
+								value={client.asdAdhd ?? undefined}
+							>
+								<SelectTrigger id="asdAdhd">
+									<SelectValue placeholder="Select status" />
+								</SelectTrigger>
+								<SelectContent>
+									{ALLOWED_ASD_ADHD_VALUES.map((value) => (
+										<SelectItem key={value} value={value}>
+											{value}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="space-y-2">
+							<Label>They have</Label>
+							<div className="py-2 font-medium text-sm">
+								{client.primaryInsurance
+									? `${client.primaryInsurance}${client.secondaryInsurance ? ` | ${client.secondaryInsurance}` : ""}`
+									: "No insurance information"}
+							</div>
+						</div>
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card className="w-full">
+				<CardHeader>
+					<CardTitle>Intake Script</CardTitle>
+				</CardHeader>
+				<CardContent className="space-y-6">
+					<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
+						<p>
+							This is {userName} from Driftwood Evaluation Center. We received
+							your referral and wanted to ask you some questions to get started
+							on our process.
+						</p>
+						{!isAdhd && (
+							<p>
+								Has the child started school yet? Do they have an IEP or 504
+								plan?
+							</p>
+						)}
+					</div>
+
+					{!isAdhd && (
+						<div className="space-y-4">
+							<div className="space-y-3">
+								<Label className="font-semibold">
+									School / IEP / 504 Status
+								</Label>
+								<RadioGroup
+									className="flex flex-wrap gap-4"
+									disabled={readOnly || updateClientMutation.isPending}
+									onValueChange={(value) => {
+										setSchoolIepStatus(value);
+										handleReferralDataChange({ schoolIepStatus: value });
+									}}
+									value={schoolIepStatus}
+								>
+									<div className="flex items-center space-x-2">
+										<RadioGroupItem id="yes" value="yes" />
+										<Label className="font-normal" htmlFor="yes">
+											Yes
+										</Label>
+									</div>
+									<div className="flex items-center space-x-2">
+										<RadioGroupItem id="no" value="no" />
+										<Label className="font-normal" htmlFor="no">
+											No
+										</Label>
+									</div>
+									<div className="flex items-center space-x-2">
+										<RadioGroupItem id="idk" value="idk" />
+										<Label className="font-normal" htmlFor="idk">
+											I Don't Know
+										</Label>
+									</div>
+								</RadioGroup>
+							</div>
+
+							<div className="space-y-2">
+								<Label className="font-semibold" htmlFor="schoolExplanation">
+									Explanation
+								</Label>
+								<Textarea
+									disabled={readOnly || updateClientMutation.isPending}
+									id="schoolExplanation"
+									onBlur={() => {
+										if (
+											schoolExplanation !==
+											(client.referralData?.schoolExplanation ?? "")
+										) {
+											handleReferralDataChange({ schoolExplanation });
+										}
+									}}
+									onChange={(e) => setMoreInfo(e.target.value)}
+									placeholder="..."
+									value={schoolExplanation}
+								/>
+							</div>
+						</div>
+					)}
+
+					<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
+						<p>
+							I just want to confirm you have concerns about {asdAdhdValue}.
+						</p>
+						<p>
+							We would like to set you up in our Patient Portal. To do that, we
+							need to send you an email. Can I please have your email address?
+						</p>
+					</div>
+
+					<div className="space-y-4">
+						<div className="space-y-2">
+							<Label className="font-semibold" htmlFor="email">
+								Email Address
+							</Label>
+							<Input
+								disabled={readOnly || updateClientMutation.isPending}
+								id="email"
+								onBlur={() => {
+									if (email !== (client.email ?? "")) {
+										handleEmailChange(email);
+									}
+								}}
+								onChange={(e) => setEmail(e.target.value)}
+								placeholder="Enter email address..."
+								type="email"
+								value={email}
+							/>
+						</div>
+
+						<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
+							<p>
+								Once you receive that email, please sign into the Patient
+								Portal. You will use the client's date of birth. Let me know if
+								you have trouble with that process.
+							</p>
+
+							<p>
+								Once you're in the portal, there will be documents to sign. They
+								usually will pop up as part of the sign-up process. Please
+								complete them so we can move forward.
+							</p>
+
+							{isAdhd ? (
+								<>
+									<p>
+										We will send you a questionnaire through the portal soon.
+										Look for a new message, which is usually in the upper right
+										hand corner of the screen. You will also get an email
+										telling you that you have a new message.
+									</p>
+									<p>
+										We will contact you after this is done to set up the
+										appointment.
+									</p>
+									<p>
+										This appointment takes 1 hour and can be done either
+										virtually or in person.
+									</p>
+								</>
+							) : (
+								<>
+									{schoolIepStatus === "yes" && (
+										<p>
+											We will request records from the school district and then
+											be in touch to discuss next steps.
+										</p>
+									)}
+									{schoolIepStatus === "no" && (
+										<p>
+											We will send you a questionnaire through the portal soon.
+											Look for a new message, which is usually in the upper
+											right hand corner of the screen. You will also get an
+											email telling you that you have a new message.
+										</p>
+									)}
+									<p>
+										Generally, we will schedule an intake appointment via
+										Telehealth. From there, we will request approval from
+										insurance before sending more questionnaires in order to get
+										the in-person comprehensive evaluation scheduled.
+									</p>
+									<p>
+										This process takes approximately 6 months to complete, so
+										please be patient with us as we help as many people as
+										possible across the state.
+									</p>
+								</>
+							)}
+						</div>
+
+						{isAdhd && (
+							<div className="space-y-2">
+								<Label className="font-semibold">Preference?</Label>
+								<RadioGroup
+									className="flex flex-wrap gap-4"
+									disabled={readOnly || updateClientMutation.isPending}
+									onValueChange={(value) => {
+										setLocationPreference(value);
+										handleReferralDataChange({ locationPreference: value });
+									}}
+									value={locationPreference}
+								>
+									<div className="flex items-center space-x-2">
+										<RadioGroupItem id="virtual" value="virtual" />
+										<Label className="font-normal" htmlFor="virtual">
+											Virtual
+										</Label>
+									</div>
+									<div className="flex items-center space-x-2">
+										<RadioGroupItem id="in-person" value="in-person" />
+										<Label className="font-normal" htmlFor="in-person">
+											In Person
+										</Label>
+									</div>
+								</RadioGroup>
+							</div>
+						)}
+						<div className="space-y-2">
+							<Label className="font-semibold" htmlFor="otherNotes">
+								Other Notes
+							</Label>
+							<Textarea
+								disabled={readOnly || updateClientMutation.isPending}
+								id="otherNotes"
+								onBlur={() => {
+									if (otherNotes !== (client.referralData?.otherNotes ?? "")) {
+										handleReferralDataChange({ otherNotes });
+									}
+								}}
+								onChange={(e) => setOtherNotes(e.target.value)}
+								placeholder="..."
+								value={otherNotes}
+							/>
+						</div>
+					</div>
+					{!punchClient && !isLoadingPunchClient && (
+						<Button onClick={() => pushToPunchMutation.mutate(client.id)}>
+							Push to Punch
+						</Button>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -18,13 +18,16 @@ import { Textarea } from "@ui/textarea";
 import { differenceInMonths, differenceInYears } from "date-fns";
 import {
 	AlertCircle,
+	Armchair,
 	ArrowUpCircle,
 	Check,
+	Copy,
 	InfoIcon,
 	Loader2,
 	LockIcon,
 	Square,
 } from "lucide-react";
+import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -37,6 +40,9 @@ interface ReferralTabProps {
 	client: Client;
 	readOnly?: boolean;
 }
+
+const TA_MESSAGE =
+	"Welcome to Driftwood! Thank you for setting up access to our patient portal. In the coming days, you should receive another message here with links to up to five questionnaires. Please complete each questionnaire completely so that we can move forward in scheduling an appointment for the client. Additionally, please review this information in preparation for your upcoming appointment: https://driftwoodeval.com/eval-process";
 
 export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 	const { data: session } = useSession();
@@ -442,16 +448,31 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 					</div>
 
 					<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
-						<h3 className="font-semibold">TherapyAppointment Message</h3>
-						<p>
-							Welcome to Driftwood! Thank you for setting up access to our
-							patient portal. In the coming days, you should receive another
-							message here with links to up to five questionnaires. Please
-							complete each questionnaire completely so that we can move forward
-							in scheduling an appointment for the client. Additionally, please
-							review this information in preparation for your upcoming
-							appointment: https://driftwoodeval.com/eval-process
-						</p>
+						<div className="flex w-full items-center justify-between">
+							<h3 className="font-semibold">TherapyAppointment Message</h3>
+							<div className="flex items-center gap-2">
+								<Button
+									className="h-8 w-8"
+									onClick={() => {
+										void navigator.clipboard.writeText(TA_MESSAGE);
+										toast.success("Copied to clipboard");
+									}}
+									size="icon"
+									variant="ghost"
+								>
+									<Copy className="h-4 w-4" />
+								</Button>
+								{client.taHash && (
+									<Link
+										href={`https://api.portal.therapyappointment.com/n/client/${client.taHash}`}
+										target="_blank"
+									>
+										<Armchair height="16" width="16" />
+									</Link>
+								)}
+							</div>
+						</div>
+						<p>{TA_MESSAGE}</p>
 					</div>
 
 					{isNeedsReview && can("clients:pushtopunch") && !punchClient && (

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Alert, AlertDescription, AlertTitle } from "@ui/alert";
 import { Button } from "@ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@ui/card";
 import { Input } from "@ui/input";
@@ -14,6 +15,7 @@ import {
 } from "@ui/select";
 import { Textarea } from "@ui/textarea";
 import { differenceInMonths, differenceInYears } from "date-fns";
+import { AlertCircle } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -118,8 +120,23 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 	const ageInYears = differenceInYears(new Date(), new Date(client.dob));
 	const showSchoolQuestion = !isAdhd && ageInMonths >= 33 && ageInYears <= 19;
 
+	const isBabyNet =
+		client.babyNet ||
+		client.primaryInsurance?.toLowerCase().includes("babynet") ||
+		client.secondaryInsurance?.toLowerCase().includes("babynet");
+
 	return (
 		<div className="flex flex-col gap-4">
+			{isBabyNet && (
+				<Alert variant="destructive">
+					<AlertCircle className="h-4 w-4" />
+					<AlertTitle>REFERRAL TAB SHOULD NOT BE USED</AlertTitle>
+					<AlertDescription>
+						REFERRAL TAB SHOULD NOT BE USED BASED ON BABYNET STATUS
+					</AlertDescription>
+				</Alert>
+			)}
+
 			<Card className="w-full">
 				<CardHeader>
 					<CardTitle>Referral Information</CardTitle>

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -13,6 +13,7 @@ import {
 	SelectValue,
 } from "@ui/select";
 import { Textarea } from "@ui/textarea";
+import { differenceInMonths, differenceInYears } from "date-fns";
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -113,6 +114,10 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 	const asdAdhdValue = client.asdAdhd ?? "(Diagnosis)";
 	const isAdhd = client.asdAdhd === "ADHD";
 
+	const ageInMonths = differenceInMonths(new Date(), new Date(client.dob));
+	const ageInYears = differenceInYears(new Date(), new Date(client.dob));
+	const showSchoolQuestion = !isAdhd && ageInMonths >= 33 && ageInYears <= 19;
+
 	return (
 		<div className="flex flex-col gap-4">
 			<Card className="w-full">
@@ -172,7 +177,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 								.replace("LD", "learning disability")}
 							.
 						</p>
-						{!isAdhd && (
+						{showSchoolQuestion && (
 							<p>
 								Has the child been evaluated at school? Do they have an IEP or
 								504 plan?
@@ -180,7 +185,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 						)}
 					</div>
 
-					{!isAdhd && (
+					{showSchoolQuestion && (
 						<div className="space-y-4">
 							<div className="space-y-3">
 								<Label className="font-semibold">

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -277,7 +277,6 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 				<CardContent className="space-y-6">
 					<div className="flex flex-col gap-4">
 						<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
-							<p className="font-bold">Say the following:</p>
 							<p>
 								This is {userName} from Driftwood Evaluation Center. We received
 								your referral and wanted to ask you some questions to get
@@ -296,7 +295,6 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 						{isUnder3 && (
 							<div className="space-y-4">
 								<div className="rounded-lg bg-muted p-4 text-sm">
-									<p className="font-bold">Say the following:</p>
 									<p>Is the child being followed by BabyNet?</p>
 								</div>
 								<div className="space-y-3 px-4">
@@ -330,7 +328,6 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 
 								{followedByBabyNet === "yes" && (
 									<div className="rounded-lg bg-muted p-4 text-sm">
-										<p className="font-bold">Say the following:</p>
 										<p>
 											Tell your Early Interventionalist (EI) to go to
 											driftwoodeval.com/babynet and fill in our referral form.
@@ -343,7 +340,6 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 						{showSchoolQuestion && (
 							<div className="space-y-4">
 								<div className="rounded-lg bg-muted p-4 text-sm">
-									<p className="font-bold">Say the following:</p>
 									<p>
 										Has the child been evaluated at school? Do they have an IEP
 										or 504 plan?
@@ -413,7 +409,6 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 					</div>
 
 					<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
-						<p className="font-bold">Say the following:</p>
 						<p>
 							We would like to set you up in our{" "}
 							{client.taHash ? (
@@ -457,7 +452,6 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 						</div>
 
 						<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
-							<p className="font-bold">Say the following:</p>
 							<p>
 								Once you receive that email, please sign into the Patient
 								Portal. You will use the client's date of birth. Let me know if
@@ -556,7 +550,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 						</div>
 					</div>
 
-					<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
+					<div className="flex flex-col gap-2 rounded-lg bg-accent p-4 text-accent-foreground text-sm">
 						<div className="flex w-full items-center justify-between">
 							<h3 className="font-semibold">TherapyAppointment Message</h3>
 							<div className="flex items-center gap-2">

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -220,7 +220,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 						/>
 					</div>
 
-					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+					<div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
 						<div className="space-y-2">
 							<Label htmlFor="asdAdhd">This is for</Label>
 							<Select

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -42,7 +42,7 @@ interface ReferralTabProps {
 }
 
 const TA_MESSAGE =
-	"Welcome to Driftwood! Thank you for setting up access to our patient portal. In the coming days, you should receive another message here with links to up to five questionnaires. Please complete each questionnaire completely so that we can move forward in scheduling an appointment for the client. Additionally, please review this information in preparation for your upcoming appointment: https://driftwoodeval.com/eval-process";
+	"Welcome to Driftwood! Thank you for setting up access to our patient portal. In the coming days, you should receive another message here with links to questionnaires. Please complete each questionnaire completely so that we can move forward in scheduling an appointment. Failure to do so will prevent you from moving forward.\n\nAdditionally, please review this information to better understand our process: https://driftwoodeval.com/eval-process";
 
 export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 	const { data: session } = useSession();
@@ -334,7 +334,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 							)}{" "}
 							. To do that, we need to send you an email.{" "}
 							{client.email
-								? `I just want to confirm that your email is "${client.email}"?`
+								? `I want to confirm that your email is "${client.email}"?`
 								: "Can I please have your email address?"}
 						</p>
 					</div>
@@ -393,13 +393,15 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 								</>
 							) : (
 								<>
+									{ageInYears <= 19 && (
+										<p>
+											We will request records from the school district and then
+											be in touch to discuss next steps.
+										</p>
+									)}
 									<p>
-										We will request records from the school district and then be
-										in touch to discuss next steps.
-									</p>
-									<p>
-										Generally, we will schedule an intake appointment via
-										Telehealth. From there, we will request approval from
+										Generally, we will schedule an intake appointment via video
+										call/Telehealth. From there, we will request approval from
 										insurance before sending more questionnaires in order to get
 										the in-person comprehensive evaluation scheduled.
 									</p>
@@ -483,7 +485,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 								)}
 							</div>
 						</div>
-						<p>{TA_MESSAGE}</p>
+						<p className="whitespace-pre-wrap">{TA_MESSAGE}</p>
 					</div>
 
 					{isNeedsReview && can("clients:pushtopunch") && !punchClient && (

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -2,7 +2,13 @@
 
 import { Alert, AlertDescription, AlertTitle } from "@ui/alert";
 import { Button } from "@ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@ui/card";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@ui/card";
 import { Checkbox } from "@ui/checkbox";
 import { Input } from "@ui/input";
 import { Label } from "@ui/label";
@@ -65,6 +71,9 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 	const [email, setEmail] = useState<string>(
 		client.referralData?.email ?? client.email ?? "",
 	);
+	const [followedByBabyNet, setFollowedByBabyNet] = useState<
+		"yes" | "no" | null
+	>(client.referralData?.followedByBabyNet ?? null);
 
 	useEffect(() => {
 		setNotes(client.referralData?.notes ?? "");
@@ -73,6 +82,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 		setOtherNotes(client.referralData?.otherNotes ?? "");
 		setLocationPreference(client.referralData?.locationPreference ?? "");
 		setEmail(client.referralData?.email ?? client.email ?? "");
+		setFollowedByBabyNet(client.referralData?.followedByBabyNet ?? null);
 	}, [client.referralData, client.email]);
 
 	const updateClientMutation = api.clients.update.useMutation({
@@ -128,11 +138,13 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 		locationPreference?: string;
 		needsReachOut?: "reach_out" | "review" | null;
 		email?: string;
+		followedByBabyNet?: "yes" | "no" | null;
 	}) => {
 		const newReferralData = {
 			...client.referralData,
 			...updates,
 		};
+
 		updateClientMutation.mutate({
 			clientId: client.id,
 			referralData: newReferralData,
@@ -146,6 +158,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 	const ageInMonths = differenceInMonths(new Date(), new Date(client.dob));
 	const ageInYears = differenceInYears(new Date(), new Date(client.dob));
 	const showSchoolQuestion = !isAdhd && ageInMonths >= 33 && ageInYears <= 19;
+	const isUnder3 = ageInYears < 3;
 
 	const isBabyNet =
 		client.babyNet ||
@@ -256,90 +269,151 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 			<Card className="w-full">
 				<CardHeader>
 					<CardTitle>Intake Script</CardTitle>
+					<CardDescription>
+						Call the client or the client's parent/guardian and follow the
+						script below. Fill in information into the form fields.
+					</CardDescription>
 				</CardHeader>
 				<CardContent className="space-y-6">
-					<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
-						<p>
-							This is {userName} from Driftwood Evaluation Center. We received
-							your referral and wanted to ask you some questions to get started
-							on our process.
-						</p>
-						<p>
-							I just want to confirm you and/or your pediatrician have concerns
-							about potential{" "}
-							{asdAdhdValue
-								.replace("ASD", "autism")
-								.replace("LD", "learning disability")}
-							.
-						</p>
-						{showSchoolQuestion && (
+					<div className="flex flex-col gap-4">
+						<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
+							<p className="font-bold">Say the following:</p>
 							<p>
-								Has the child been evaluated at school? Do they have an IEP or
-								504 plan?
+								This is {userName} from Driftwood Evaluation Center. We received
+								your referral and wanted to ask you some questions to get
+								started on our process.
 							</p>
+							<p>
+								I just want to confirm you and/or your pediatrician have
+								concerns about potential{" "}
+								{asdAdhdValue
+									.replace("ASD", "autism")
+									.replace("LD", "learning disability")}
+								.
+							</p>
+						</div>
+
+						{isUnder3 && (
+							<div className="space-y-4">
+								<div className="rounded-lg bg-muted p-4 text-sm">
+									<p className="font-bold">Say the following:</p>
+									<p>Is the child being followed by BabyNet?</p>
+								</div>
+								<div className="space-y-3 px-4">
+									<Label className="font-semibold">BabyNet?</Label>
+									<RadioGroup
+										className="flex flex-wrap gap-4"
+										disabled={isReadOnly || updateClientMutation.isPending}
+										onValueChange={(value) => {
+											const val = value as "yes" | "no";
+											setFollowedByBabyNet(val);
+											handleReferralDataChange({
+												followedByBabyNet: val,
+											});
+										}}
+										value={followedByBabyNet ?? undefined}
+									>
+										<div className="flex items-center space-x-2">
+											<RadioGroupItem id="bn-yes" value="yes" />
+											<Label className="font-normal" htmlFor="bn-yes">
+												Yes
+											</Label>
+										</div>
+										<div className="flex items-center space-x-2">
+											<RadioGroupItem id="bn-no" value="no" />
+											<Label className="font-normal" htmlFor="bn-no">
+												No
+											</Label>
+										</div>
+									</RadioGroup>
+								</div>
+
+								{followedByBabyNet === "yes" && (
+									<div className="rounded-lg bg-muted p-4 text-sm">
+										<p className="font-bold">Say the following:</p>
+										<p>
+											Tell your Early Interventionalist (EI) to go to
+											driftwoodeval.com/babynet and fill in our referral form.
+										</p>
+									</div>
+								)}
+							</div>
+						)}
+
+						{showSchoolQuestion && (
+							<div className="space-y-4">
+								<div className="rounded-lg bg-muted p-4 text-sm">
+									<p className="font-bold">Say the following:</p>
+									<p>
+										Has the child been evaluated at school? Do they have an IEP
+										or 504 plan?
+									</p>
+								</div>
+								<div className="space-y-4 px-4">
+									<div className="space-y-3">
+										<Label className="font-semibold">
+											School / IEP / 504 Status
+										</Label>
+										<RadioGroup
+											className="flex flex-wrap gap-4"
+											disabled={isReadOnly || updateClientMutation.isPending}
+											onValueChange={(value) => {
+												setSchoolIepStatus(value);
+												handleReferralDataChange({ schoolIepStatus: value });
+											}}
+											value={schoolIepStatus}
+										>
+											<div className="flex items-center space-x-2">
+												<RadioGroupItem id="yes" value="yes" />
+												<Label className="font-normal" htmlFor="yes">
+													Yes
+												</Label>
+											</div>
+											<div className="flex items-center space-x-2">
+												<RadioGroupItem id="no" value="no" />
+												<Label className="font-normal" htmlFor="no">
+													No
+												</Label>
+											</div>
+											<div className="flex items-center space-x-2">
+												<RadioGroupItem id="idk" value="idk" />
+												<Label className="font-normal" htmlFor="idk">
+													I Don't Know
+												</Label>
+											</div>
+										</RadioGroup>
+									</div>
+
+									<div className="space-y-2">
+										<Label
+											className="font-semibold"
+											htmlFor="schoolExplanation"
+										>
+											Explanation
+										</Label>
+										<Textarea
+											disabled={isReadOnly || updateClientMutation.isPending}
+											id="schoolExplanation"
+											onBlur={() => {
+												if (
+													schoolExplanation !==
+													(client.referralData?.schoolExplanation ?? "")
+												) {
+													handleReferralDataChange({ schoolExplanation });
+												}
+											}}
+											onChange={(e) => setMoreInfo(e.target.value)}
+											placeholder="..."
+											value={schoolExplanation}
+										/>
+									</div>
+								</div>
+							</div>
 						)}
 					</div>
 
-					{showSchoolQuestion && (
-						<div className="space-y-4">
-							<div className="space-y-3">
-								<Label className="font-semibold">
-									School / IEP / 504 Status
-								</Label>
-								<RadioGroup
-									className="flex flex-wrap gap-4"
-									disabled={isReadOnly || updateClientMutation.isPending}
-									onValueChange={(value) => {
-										setSchoolIepStatus(value);
-										handleReferralDataChange({ schoolIepStatus: value });
-									}}
-									value={schoolIepStatus}
-								>
-									<div className="flex items-center space-x-2">
-										<RadioGroupItem id="yes" value="yes" />
-										<Label className="font-normal" htmlFor="yes">
-											Yes
-										</Label>
-									</div>
-									<div className="flex items-center space-x-2">
-										<RadioGroupItem id="no" value="no" />
-										<Label className="font-normal" htmlFor="no">
-											No
-										</Label>
-									</div>
-									<div className="flex items-center space-x-2">
-										<RadioGroupItem id="idk" value="idk" />
-										<Label className="font-normal" htmlFor="idk">
-											I Don't Know
-										</Label>
-									</div>
-								</RadioGroup>
-							</div>
-
-							<div className="space-y-2">
-								<Label className="font-semibold" htmlFor="schoolExplanation">
-									Explanation
-								</Label>
-								<Textarea
-									disabled={isReadOnly || updateClientMutation.isPending}
-									id="schoolExplanation"
-									onBlur={() => {
-										if (
-											schoolExplanation !==
-											(client.referralData?.schoolExplanation ?? "")
-										) {
-											handleReferralDataChange({ schoolExplanation });
-										}
-									}}
-									onChange={(e) => setMoreInfo(e.target.value)}
-									placeholder="..."
-									value={schoolExplanation}
-								/>
-							</div>
-						</div>
-					)}
-
 					<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
+						<p className="font-bold">Say the following:</p>
 						<p>
 							We would like to set you up in our{" "}
 							{client.taHash ? (
@@ -383,6 +457,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 						</div>
 
 						<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
+							<p className="font-bold">Say the following:</p>
 							<p>
 								Once you receive that email, please sign into the Patient
 								Portal. You will use the client's date of birth. Let me know if
@@ -506,6 +581,10 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 								)}
 							</div>
 						</div>
+						<p className="font-bold">
+							Go to the client's TherapyAppointment page and send them the
+							following message:
+						</p>
 						<p className="whitespace-pre-wrap">{TA_MESSAGE}</p>
 					</div>
 

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -320,8 +320,19 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 
 					<div className="flex flex-col gap-2 rounded-lg bg-muted p-4 text-sm">
 						<p>
-							We would like to set you up in our Patient Portal. To do that, we
-							need to send you an email.{" "}
+							We would like to set you up in our{" "}
+							{client.taHash ? (
+								<Link
+									className="underline"
+									href={`https://api.portal.therapyappointment.com/n/client/${client.taHash}`}
+									target="_blank"
+								>
+									Patient Portal
+								</Link>
+							) : (
+								<span>Patient Portal</span>
+							)}{" "}
+							. To do that, we need to send you an email.{" "}
 							{client.email
 								? `I just want to confirm that your email is "${client.email}"?`
 								: "Can I please have your email address?"}

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -49,6 +49,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 	const can = useCheckPermission();
 	const utils = api.useUtils();
 
+	const [notes, setNotes] = useState<string>(client.referralData?.notes ?? "");
 	const [schoolIepStatus, setSchoolIepStatus] = useState<string>(
 		client.referralData?.schoolIepStatus ?? "",
 	);
@@ -66,6 +67,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 	);
 
 	useEffect(() => {
+		setNotes(client.referralData?.notes ?? "");
 		setSchoolIepStatus(client.referralData?.schoolIepStatus ?? "");
 		setMoreInfo(client.referralData?.schoolExplanation ?? "");
 		setOtherNotes(client.referralData?.otherNotes ?? "");
@@ -119,6 +121,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 	};
 
 	const handleReferralDataChange = (updates: {
+		notes?: string;
 		schoolIepStatus?: string;
 		schoolExplanation?: string;
 		otherNotes?: string;
@@ -199,6 +202,24 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 					</div>
 				</CardHeader>
 				<CardContent className="space-y-4">
+					<div className="space-y-2">
+						<Label className="font-semibold" htmlFor="referralNotes">
+							Notes
+						</Label>
+						<Textarea
+							disabled={isReadOnly || updateClientMutation.isPending}
+							id="referralNotes"
+							onBlur={() => {
+								if (notes !== (client.referralData?.notes ?? "")) {
+									handleReferralDataChange({ notes });
+								}
+							}}
+							onChange={(e) => setNotes(e.target.value)}
+							placeholder="Add referral notes here..."
+							value={notes}
+						/>
+					</div>
+
 					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
 						<div className="space-y-2">
 							<Label htmlFor="asdAdhd">This is for</Label>

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -114,7 +114,8 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 
 	const { data: pushPreview, isLoading: isLoadingPreview } =
 		api.google.getPushPreview.useQuery(client.id, {
-			enabled: !!client.id && isNeedsReview && can("clients:pushtopunch"),
+			enabled:
+				!!client.id && isNeedsReview && can("clients:referral:pushtopunch"),
 		});
 
 	const isReadOnly = readOnly || !!punchClient;
@@ -195,7 +196,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 								isReadOnly ||
 								updateClientMutation.isPending ||
 								isNeedsReview ||
-								!can("clients:reachout")
+								!can("clients:referral:infobox")
 							}
 							id="needsReachOutReferral"
 							onCheckedChange={(checked) =>
@@ -215,7 +216,11 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 							Notes
 						</Label>
 						<Textarea
-							disabled={isReadOnly || updateClientMutation.isPending}
+							disabled={
+								isReadOnly ||
+								updateClientMutation.isPending ||
+								!can("clients:referral:infobox")
+							}
 							id="referralNotes"
 							onBlur={() => {
 								if (notes !== (client.referralData?.notes ?? "")) {
@@ -232,7 +237,11 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 						<div className="space-y-2">
 							<Label htmlFor="asdAdhd">This is for</Label>
 							<Select
-								disabled={isReadOnly || updateClientMutation.isPending}
+								disabled={
+									isReadOnly ||
+									updateClientMutation.isPending ||
+									!can("clients:asdadhd")
+								}
 								onValueChange={handleAsdAdhdChange}
 								value={client.asdAdhd ?? undefined}
 							>
@@ -296,7 +305,11 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 									<Label className="font-semibold">BabyNet?</Label>
 									<RadioGroup
 										className="flex flex-wrap gap-4"
-										disabled={isReadOnly || updateClientMutation.isPending}
+										disabled={
+											isReadOnly ||
+											updateClientMutation.isPending ||
+											!can("clients:referral:fillout")
+										}
 										onValueChange={(value) => {
 											const val = value as "yes" | "no";
 											setFollowedByBabyNet(val);
@@ -346,7 +359,11 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 											School Notes
 										</Label>
 										<Textarea
-											disabled={isReadOnly || updateClientMutation.isPending}
+											disabled={
+												isReadOnly ||
+												updateClientMutation.isPending ||
+												!can("clients:referral:fillout")
+											}
 											id="schoolExplanation"
 											onBlur={() => {
 												if (
@@ -393,7 +410,11 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 								Email Address
 							</Label>
 							<Input
-								disabled={isReadOnly || updateClientMutation.isPending}
+								disabled={
+									isReadOnly ||
+									updateClientMutation.isPending ||
+									!can("clients:referral:fillout")
+								}
 								id="email"
 								onBlur={() => {
 									if (
@@ -467,7 +488,11 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 								<Label className="font-semibold">Preference?</Label>
 								<RadioGroup
 									className="flex flex-wrap gap-4"
-									disabled={isReadOnly || updateClientMutation.isPending}
+									disabled={
+										isReadOnly ||
+										updateClientMutation.isPending ||
+										!can("clients:referral:fillout")
+									}
 									onValueChange={(value) => {
 										setLocationPreference(value);
 										handleReferralDataChange({ locationPreference: value });
@@ -494,7 +519,11 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 								Other Notes
 							</Label>
 							<Textarea
-								disabled={isReadOnly || updateClientMutation.isPending}
+								disabled={
+									isReadOnly ||
+									updateClientMutation.isPending ||
+									!can("clients:referral:fillout")
+								}
 								id="otherNotes"
 								onBlur={() => {
 									if (otherNotes !== (client.referralData?.otherNotes ?? "")) {
@@ -541,69 +570,71 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 						<p className="whitespace-pre-wrap">{TA_MESSAGE}</p>
 					</div>
 
-					{isNeedsReview && can("clients:pushtopunch") && !punchClient && (
-						<Alert className="bg-secondary/20">
-							<InfoIcon className="h-4 w-4" />
-							<AlertTitle>Push to Punch Preview</AlertTitle>
-							<AlertDescription>
-								{isLoadingPreview ? (
-									<Loader2 className="h-4 w-4 animate-spin" />
-								) : pushPreview ? (
-									<div className="mt-2 grid grid-cols-2 items-center gap-x-4 gap-y-1 text-xs">
-										<span className="font-semibold text-muted-foreground uppercase">
-											Primary:
-										</span>
-										<span>{pushPreview.primaryPayer}</span>
-										{pushPreview.secondaryPayer && (
-											<>
-												<span className="font-semibold text-muted-foreground uppercase">
-													Secondary:
-												</span>
-												<span>{pushPreview.secondaryPayer}</span>
-											</>
-										)}
-										<span className="font-semibold text-muted-foreground uppercase">
-											For:
-										</span>
-										<span>{pushPreview.asdAdhd}</span>
-										<span className="font-semibold text-muted-foreground uppercase">
-											Location:
-										</span>
-										<span>{pushPreview.location ?? "Unknown"}</span>
-										<span className="font-semibold text-muted-foreground uppercase">
-											DA Qs:
-										</span>
-										<span>
-											{pushPreview.daQsNeeded ? (
-												<Check className="h-3 w-3" />
-											) : (
-												<Square className="h-3 w-3 text-muted-foreground" />
+					{isNeedsReview &&
+						can("clients:referral:pushtopunch") &&
+						!punchClient && (
+							<Alert className="bg-secondary/20">
+								<InfoIcon className="h-4 w-4" />
+								<AlertTitle>Push to Punch Preview</AlertTitle>
+								<AlertDescription>
+									{isLoadingPreview ? (
+										<Loader2 className="h-4 w-4 animate-spin" />
+									) : pushPreview ? (
+										<div className="mt-2 grid grid-cols-2 items-center gap-x-4 gap-y-1 text-xs">
+											<span className="font-semibold text-muted-foreground uppercase">
+												Primary:
+											</span>
+											<span>{pushPreview.primaryPayer}</span>
+											{pushPreview.secondaryPayer && (
+												<>
+													<span className="font-semibold text-muted-foreground uppercase">
+														Secondary:
+													</span>
+													<span>{pushPreview.secondaryPayer}</span>
+												</>
 											)}
-										</span>
-										<span className="font-semibold text-muted-foreground uppercase">
-											EVAL Qs:
-										</span>
-										<span>
-											{pushPreview.evalQsNeeded ? (
-												<Check className="h-3 w-3" />
-											) : (
-												<Square className="h-3 w-3 text-muted-foreground" />
-											)}
-										</span>
-										<span className="col-span-2 my-1">
-											Additionally, pushing will update this data in the EMR:
-										</span>
-										<span className="font-semibold text-muted-foreground uppercase">
-											Records:
-										</span>
-										<span>{pushPreview.recordsNeeded ?? "Not Needed"}</span>
-									</div>
-								) : (
-									"Failed to load preview."
-								)}
-							</AlertDescription>
-						</Alert>
-					)}
+											<span className="font-semibold text-muted-foreground uppercase">
+												For:
+											</span>
+											<span>{pushPreview.asdAdhd}</span>
+											<span className="font-semibold text-muted-foreground uppercase">
+												Location:
+											</span>
+											<span>{pushPreview.location ?? "Unknown"}</span>
+											<span className="font-semibold text-muted-foreground uppercase">
+												DA Qs:
+											</span>
+											<span>
+												{pushPreview.daQsNeeded ? (
+													<Check className="h-3 w-3" />
+												) : (
+													<Square className="h-3 w-3 text-muted-foreground" />
+												)}
+											</span>
+											<span className="font-semibold text-muted-foreground uppercase">
+												EVAL Qs:
+											</span>
+											<span>
+												{pushPreview.evalQsNeeded ? (
+													<Check className="h-3 w-3" />
+												) : (
+													<Square className="h-3 w-3 text-muted-foreground" />
+												)}
+											</span>
+											<span className="col-span-2 my-1">
+												Additionally, pushing will update this data in the EMR:
+											</span>
+											<span className="font-semibold text-muted-foreground uppercase">
+												Records:
+											</span>
+											<span>{pushPreview.recordsNeeded ?? "Not Needed"}</span>
+										</div>
+									) : (
+										"Failed to load preview."
+									)}
+								</AlertDescription>
+							</Alert>
+						)}
 
 					<div className="flex flex-wrap gap-2">
 						<Button
@@ -611,7 +642,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 							disabled={
 								isReadOnly ||
 								updateClientMutation.isPending ||
-								!can("clients:reviewreachout")
+								!can("clients:referral:fillout")
 							}
 							onClick={() =>
 								handleReferralDataChange({
@@ -623,7 +654,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 							{isNeedsReview ? "Marked for Review" : "Mark for Review"}
 						</Button>
 
-						{isNeedsReview && can("clients:pushtopunch") && (
+						{isNeedsReview && can("clients:referral:pushtopunch") && (
 							<Button
 								className="w-full sm:w-auto"
 								disabled={

--- a/src/app/_components/client/ReferralTab.tsx
+++ b/src/app/_components/client/ReferralTab.tsx
@@ -56,10 +56,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 	const utils = api.useUtils();
 
 	const [notes, setNotes] = useState<string>(client.referralData?.notes ?? "");
-	const [schoolIepStatus, setSchoolIepStatus] = useState<string>(
-		client.referralData?.schoolIepStatus ?? "",
-	);
-	const [schoolExplanation, setMoreInfo] = useState<string>(
+	const [schoolExplanation, setSchoolExplanation] = useState<string>(
 		client.referralData?.schoolExplanation ?? "",
 	);
 	const [otherNotes, setOtherNotes] = useState<string>(
@@ -77,8 +74,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 
 	useEffect(() => {
 		setNotes(client.referralData?.notes ?? "");
-		setSchoolIepStatus(client.referralData?.schoolIepStatus ?? "");
-		setMoreInfo(client.referralData?.schoolExplanation ?? "");
+		setSchoolExplanation(client.referralData?.schoolExplanation ?? "");
 		setOtherNotes(client.referralData?.otherNotes ?? "");
 		setLocationPreference(client.referralData?.locationPreference ?? "");
 		setEmail(client.referralData?.email ?? client.email ?? "");
@@ -132,7 +128,6 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 
 	const handleReferralDataChange = (updates: {
 		notes?: string;
-		schoolIepStatus?: string;
 		schoolExplanation?: string;
 		otherNotes?: string;
 		locationPreference?: string;
@@ -210,7 +205,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 							}
 						/>
 						<Label className="font-medium" htmlFor="needsReachOutReferral">
-							Needs Reach Out
+							Needs Outreach
 						</Label>
 					</div>
 				</CardHeader>
@@ -340,52 +335,15 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 						{showSchoolQuestion && (
 							<div className="space-y-4">
 								<div className="rounded-lg bg-muted p-4 text-sm">
-									<p>
-										Has the child been evaluated at school? Do they have an IEP
-										or 504 plan?
-									</p>
+									<p>Does the child go to charter / private school?</p>
 								</div>
-								<div className="space-y-4 px-4">
-									<div className="space-y-3">
-										<Label className="font-semibold">
-											School / IEP / 504 Status
-										</Label>
-										<RadioGroup
-											className="flex flex-wrap gap-4"
-											disabled={isReadOnly || updateClientMutation.isPending}
-											onValueChange={(value) => {
-												setSchoolIepStatus(value);
-												handleReferralDataChange({ schoolIepStatus: value });
-											}}
-											value={schoolIepStatus}
-										>
-											<div className="flex items-center space-x-2">
-												<RadioGroupItem id="yes" value="yes" />
-												<Label className="font-normal" htmlFor="yes">
-													Yes
-												</Label>
-											</div>
-											<div className="flex items-center space-x-2">
-												<RadioGroupItem id="no" value="no" />
-												<Label className="font-normal" htmlFor="no">
-													No
-												</Label>
-											</div>
-											<div className="flex items-center space-x-2">
-												<RadioGroupItem id="idk" value="idk" />
-												<Label className="font-normal" htmlFor="idk">
-													I Don't Know
-												</Label>
-											</div>
-										</RadioGroup>
-									</div>
-
+								<div className="space-y-4">
 									<div className="space-y-2">
 										<Label
 											className="font-semibold"
 											htmlFor="schoolExplanation"
 										>
-											Explanation
+											School Notes
 										</Label>
 										<Textarea
 											disabled={isReadOnly || updateClientMutation.isPending}
@@ -398,7 +356,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 													handleReferralDataChange({ schoolExplanation });
 												}
 											}}
-											onChange={(e) => setMoreInfo(e.target.value)}
+											onChange={(e) => setSchoolExplanation(e.target.value)}
 											placeholder="..."
 											value={schoolExplanation}
 										/>
@@ -455,7 +413,7 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 							<p>
 								Once you receive that email, please sign into the Patient
 								Portal. You will use the client's date of birth. Let me know if
-								you have trouble with that process.
+								you have any questions with that process.
 							</p>
 
 							<p>
@@ -576,8 +534,9 @@ export function ReferralTab({ client, readOnly }: ReferralTabProps) {
 							</div>
 						</div>
 						<p className="font-bold">
-							Go to the client's TherapyAppointment page and send them the
-							following message:
+							Copy the message below by clicking the two boxes in the top right.
+							Go to the client's TherapyAppointment page by clicking the chair
+							icon and send them the following message:
 						</p>
 						<p className="whitespace-pre-wrap">{TA_MESSAGE}</p>
 					</div>

--- a/src/app/_components/dashboard/Dashboard.tsx
+++ b/src/app/_components/dashboard/Dashboard.tsx
@@ -275,7 +275,8 @@ export function Dashboard() {
 					{
 						title: "Needs Reach Out",
 						clients: filteredNeedsReachOut as DashboardClient[],
-						description: "Clients marked as needing reach out.",
+						description:
+							"Clients marked as needing reach out. They are in TherapyAppointment but not on the prioritization sheet.",
 						subheading: "Referrals",
 					},
 				]
@@ -285,7 +286,8 @@ export function Dashboard() {
 					{
 						title: "Reached Out - Needs Review",
 						clients: filteredNeedsReview as DashboardClient[],
-						description: "Clients marked for review.",
+						description:
+							"Clients marked for review before pushing to prioritization sheet.",
 						subheading:
 							filteredNeedsReachOut.length > 0 ? undefined : "Referrals",
 					},

--- a/src/app/_components/dashboard/Dashboard.tsx
+++ b/src/app/_components/dashboard/Dashboard.tsx
@@ -243,59 +243,9 @@ export function Dashboard() {
 	const finalSections = getDashboardSections(
 		dashboardData?.punchClients,
 		dashboardData?.missingClients,
+		needsReachOut,
+		needsReview,
 	);
-
-	const punchClientIds = useMemo(() => {
-		return new Set(
-			dashboardData?.punchClients
-				?.map((c) => c["Client ID"])
-				.filter(
-					(id): id is string => typeof id === "string" && id.trim() !== "",
-				)
-				.map((id) => parseInt(id, 10))
-				.filter((id) => !Number.isNaN(id)) ?? [],
-		);
-	}, [dashboardData?.punchClients]);
-
-	const filteredNeedsReachOut = useMemo(() => {
-		return (
-			needsReachOut?.filter((client) => !punchClientIds.has(client.id)) ?? []
-		);
-	}, [needsReachOut, punchClientIds]);
-
-	const filteredNeedsReview = useMemo(() => {
-		return (
-			needsReview?.filter((client) => !punchClientIds.has(client.id)) ?? []
-		);
-	}, [needsReview, punchClientIds]);
-
-	const referralSections = [
-		...(filteredNeedsReachOut.length > 0
-			? [
-					{
-						title: "Needs Outreach",
-						clients: filteredNeedsReachOut as DashboardClient[],
-						description:
-							"Clients marked as needing reach out. They are in TherapyAppointment but not on the prioritization sheet.",
-						subheading: "Referrals",
-					},
-				]
-			: []),
-		...(filteredNeedsReview.length > 0
-			? [
-					{
-						title: "Reached Out - Needs Review",
-						clients: filteredNeedsReview as DashboardClient[],
-						description:
-							"Clients marked for review before pushing to prioritization sheet.",
-						subheading:
-							filteredNeedsReachOut.length > 0 ? undefined : "Referrals",
-					},
-				]
-			: []),
-	];
-
-	const allDashboardSections = [...referralSections, ...finalSections];
 
 	if (isLoading)
 		return (
@@ -329,7 +279,7 @@ export function Dashboard() {
 					Punchlist: {dashboardData?.punchClients?.length ?? 0}
 				</p>
 
-				{allDashboardSections.map((section) => (
+				{finalSections.map((section) => (
 					<Fragment key={section.title}>
 						{section.subheading && (
 							<h2 className="mt-6 mb-2 self-start font-bold text-lg">

--- a/src/app/_components/dashboard/Dashboard.tsx
+++ b/src/app/_components/dashboard/Dashboard.tsx
@@ -273,7 +273,7 @@ export function Dashboard() {
 		...(filteredNeedsReachOut.length > 0
 			? [
 					{
-						title: "Needs Reach Out",
+						title: "Needs Outreach",
 						clients: filteredNeedsReachOut as DashboardClient[],
 						description:
 							"Clients marked as needing reach out. They are in TherapyAppointment but not on the prioritization sheet.",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -34,6 +34,7 @@ export const PERMISSIONS = {
 					{ id: "clients:drive", title: "Edit Drive Links" },
 					{ id: "clients:schooldistrict", title: "Edit School District" },
 					{ id: "clients:asdadhd", title: "Edit ASD/ADHD" },
+					{ id: "clients:email", title: "Edit Client Email" },
 					{ id: "clients:protocolsscanned", title: "Edit Protocols Scanned" },
 					{ id: "clients:babynet", title: "Edit BabyNet Status" },
 					{ id: "clients:ei", title: "Edit EI Attends Status" },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -90,6 +90,14 @@ export const PERMISSIONS = {
 					{ id: "clients:merge", title: "Merge with Real Client Record" },
 				],
 			},
+			referrals: {
+				title: "Referrals",
+				permissions: [
+					{ id: "clients:reachout", title: "Mark for Reach Out" },
+					{ id: "clients:reviewreachout", title: "Mark for Review" },
+					{ id: "clients:pushtopunch", title: "Push to Punchlist" },
+				],
+			},
 		},
 	},
 	system: {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -93,9 +93,16 @@ export const PERMISSIONS = {
 			referrals: {
 				title: "Referrals",
 				permissions: [
-					{ id: "clients:reachout", title: "Mark for Reach Out" },
-					{ id: "clients:reviewreachout", title: "Mark for Review" },
-					{ id: "clients:pushtopunch", title: "Push to Punchlist" },
+					{ id: "clients:referral:tab", title: "Access Referral Tab" },
+					{
+						id: "clients:referral:infobox",
+						title: "Fill in Referral Info (Top Box) & Mark for Reach Out",
+					},
+					{
+						id: "clients:referral:fillout",
+						title: "Fill in Referral Form & Mark for Review",
+					},
+					{ id: "clients:referral:pushtopunch", title: "Push to Punchlist" },
 				],
 			},
 		},

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -7,6 +7,8 @@ export const SECTION_MULTIPLE_FILTERS = "Clients in Multiple Filters";
 export const SECTION_DA_QS_DONE = "DA Qs Done";
 export const SECTION_EVAL_QS_DONE = "Eval Qs Done";
 export const SECTION_DAEVAL_QS_DONE = "DA+Eval Qs Done";
+export const SECTION_NEEDS_OUTREACH = "Needs Outreach";
+export const SECTION_REACHED_OUT_NEEDS_REVIEW = "Reached Out - Needs Review";
 
 export type DashboardClient = (FullClientInfo | Client) & {
 	matchedSections?: string[];
@@ -26,6 +28,16 @@ const sentExtraInfo = (client: FullClientInfo) => {
 	if (!Qs || Qs.length === 0) return `Not in ${env.NEXT_PUBLIC_APP_TITLE[0]}`;
 	const minReminded = Math.min(...Qs.map((q) => q.reminded ?? 0));
 	return `Reminded: ${minReminded}`;
+};
+
+const getPunchClientIds = (punchClients: FullClientInfo[] | undefined) => {
+	return new Set(
+		punchClients
+			?.map((c) => c["Client ID"])
+			.filter((id): id is string => typeof id === "string" && id.trim() !== "")
+			.map((id) => parseInt(id, 10))
+			.filter((id) => !Number.isNaN(id)) ?? [],
+	);
 };
 
 export const DASHBOARD_CONFIG: {
@@ -62,26 +74,6 @@ export const DASHBOARD_CONFIG: {
 		filter: (client: FullClientInfo) =>
 			client.babyNetERNeeded === true && client.babyNetERDownloaded === false,
 	},
-	// {
-	// 	title: "Records Reviewed - Qs Not Sent",
-	// 	description:
-	// 		"Records are ready, questionnaires are marked needed, but haven't been sent.",
-	// 	filter: (client: FullClientInfo) => {
-	// 		const isRecordsReady =
-	// 			client.recordsNeeded === "Not Needed" ||
-	// 			(client.recordsNeeded === "Needed" &&
-	// 				client.hasExternalRecordsNote === true);
-	// 		return (
-	// 			isRecordsReady &&
-	// 			((client["DA Qs Needed"] === "TRUE" &&
-	// 				client["DA Qs Sent"] === "FALSE") ||
-	// 				(client["EVAL Qs Needed"] === "TRUE" &&
-	// 					client["EVAL Qs Sent"] === "FALSE"))
-	// 		);
-	// 	},
-	// 	failureFilter: (f) =>
-	// 		f.daEval === "DA" || f.daEval === "EVAL" || f.daEval === "DAEVAL",
-	// },
 	{
 		title: "DA Qs Pending",
 		subheading: "Questionnaires",
@@ -222,7 +214,44 @@ export interface DashboardSection {
 export function getDashboardSections(
 	punchClients: FullClientInfo[] | undefined,
 	missingFromPunchlist: Client[] | undefined,
+	needsReachOut: Client[] | undefined,
+	needsReview: Client[] | undefined,
 ): DashboardSection[] {
+	const punchClientIds = getPunchClientIds(punchClients);
+
+	const referralSections: DashboardSection[] = [
+		...(needsReachOut
+			?.filter((c) => !punchClientIds.has(c.id))
+			.map((c) => ({
+				title: SECTION_NEEDS_OUTREACH,
+				clients: [c] as DashboardClient[],
+				description:
+					"Clients marked as needing reach out. They are in TherapyAppointment but not on the prioritization sheet.",
+				subheading: "Referrals",
+			}))
+			.slice(0, 1)
+			.map((s) => ({
+				...s,
+				clients: needsReachOut?.filter((c) => !punchClientIds.has(c.id)) ?? [],
+			})) ?? []),
+		...(needsReview
+			?.filter((c) => !punchClientIds.has(c.id))
+			.map((c) => ({
+				title: SECTION_REACHED_OUT_NEEDS_REVIEW,
+				clients: [c] as DashboardClient[],
+				description:
+					"Clients marked for review before pushing to prioritization sheet.",
+				subheading: needsReachOut?.some((c) => !punchClientIds.has(c.id))
+					? undefined
+					: "Referrals",
+			}))
+			.slice(0, 1)
+			.map((s) => ({
+				...s,
+				clients: needsReview?.filter((c) => !punchClientIds.has(c.id)) ?? [],
+			})) ?? []),
+	];
+
 	const filteredSections = DASHBOARD_CONFIG.map((config) => ({
 		title: config.title,
 		subheading: config.subheading,
@@ -238,33 +267,28 @@ export function getDashboardSections(
 			})) ?? [],
 	}));
 
-	const justAdded =
-		punchClients
-			?.filter((client) =>
-				DASHBOARD_CONFIG.every((config) => !config.filter(client)),
-			)
-			.map((client) => ({
-				...client,
-				failures: client.failures?.filter((f) => (f.reminded ?? 0) < 100),
-			})) ?? [];
-
-	const allSections = [
-		{
-			title: SECTION_JUST_ADDED,
-			clients: justAdded,
-			description: "Clients who don't match any specific filter criteria yet.",
-		},
-		...filteredSections,
-	];
+	const justAddedSection = {
+		title: SECTION_JUST_ADDED,
+		clients:
+			punchClients
+				?.filter((client) =>
+					DASHBOARD_CONFIG.every((config) => !config.filter(client)),
+				)
+				.map((client) => ({
+					...client,
+					failures: client.failures?.filter((f) => (f.reminded ?? 0) < 100),
+				})) ?? [],
+		description: "Clients who don't match any specific filter criteria yet.",
+	};
 
 	const clientMatchedSections = new Map<string, string[]>();
-	allSections.forEach((section) => {
-		section.clients.forEach((client) => {
+	for (const section of [justAddedSection, ...filteredSections]) {
+		for (const client of section.clients) {
 			const clientId = client["Client ID"] ?? client.id.toString();
 			const sections = clientMatchedSections.get(clientId) ?? [];
 			clientMatchedSections.set(clientId, [...sections, section.title]);
-		});
-	});
+		}
+	}
 
 	const clientsInMultipleFilters =
 		punchClients
@@ -276,7 +300,6 @@ export function getDashboardSections(
 			.map((client) => ({
 				...client,
 				matchedSections: clientMatchedSections.get(client["Client ID"] ?? ""),
-				// For this specific view, we show all relevant failures from the sections they are in
 				failures: client.failures?.filter(
 					(f) =>
 						(f.reminded ?? 0) < 100 &&
@@ -303,24 +326,41 @@ export function getDashboardSections(
 			description:
 				"Clients who match multiple dashboard filters simultaneously, which usually indicates data inconsistency.",
 		},
-		...allSections,
+		justAddedSection,
+		...referralSections,
+		...filteredSections,
 	];
 }
 
 export function getClientMatchedSections(
-	client: FullClientInfo | Client,
-	allPunchClients: FullClientInfo[],
-	missingFromPunchlist: { id: number }[],
+	client: { id: number },
+	allPunchClients: FullClientInfo[] | undefined,
+	missingFromPunchlist: Client[] | undefined,
+	needsReachOut: Client[] | undefined,
+	needsReview: Client[] | undefined,
 ) {
 	const matchedSections: string[] = [];
+	const punchClientIds = getPunchClientIds(allPunchClients);
+	const clientId = client.id;
 
-	// Check if missing from punchlist
-	if (missingFromPunchlist.some((m) => m.id === client.id)) {
+	if (
+		needsReachOut?.some((m) => m.id === clientId) &&
+		!punchClientIds.has(clientId)
+	) {
+		matchedSections.push(SECTION_NEEDS_OUTREACH);
+	}
+	if (
+		needsReview?.some((m) => m.id === clientId) &&
+		!punchClientIds.has(clientId)
+	) {
+		matchedSections.push(SECTION_REACHED_OUT_NEEDS_REVIEW);
+	}
+
+	if (missingFromPunchlist?.some((m) => m.id === clientId)) {
 		matchedSections.push(SECTION_ACTIVE_NOT_ON_PUNCHLIST);
 	}
 
-	// Check if on punchlist
-	const punchClient = allPunchClients.find((p) => p.id === client.id);
+	const punchClient = allPunchClients?.find((p) => p.id === clientId);
 	if (punchClient) {
 		let matchedAnyFilter = false;
 		for (const config of DASHBOARD_CONFIG) {
@@ -329,10 +369,7 @@ export function getClientMatchedSections(
 				matchedAnyFilter = true;
 			}
 		}
-
-		if (!matchedAnyFilter) {
-			matchedSections.push(SECTION_JUST_ADDED);
-		}
+		if (!matchedAnyFilter) matchedSections.push(SECTION_JUST_ADDED);
 	}
 
 	return matchedSections;

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -465,6 +465,80 @@ export const getClientFromPunchData = async (session: Session, id: string) => {
 	return data.find((client) => client["Client ID"] === id);
 };
 
+export const pushToPunch = async (
+	session: Session,
+	client: {
+		id: number;
+		fullName: string;
+		asdAdhd: string | null;
+		primaryPayer: string | null;
+	},
+) => {
+	const { PUNCHLIST_ID, PUNCHLIST_RANGE } = env;
+	const sheetsApi = getSheetsClient(session);
+
+	const response = await sheetsApi.spreadsheets.values.get({
+		spreadsheetId: PUNCHLIST_ID,
+		range: PUNCHLIST_RANGE,
+	});
+
+	const data = response.data.values ?? [];
+	const headers = data[0] ?? [];
+	const rows = data.slice(1);
+
+	// Find the first blank row (where Client ID at index 1 is empty or whitespace)
+	let targetRowIndex = rows.findIndex(
+		(row) => !row[1] || row[1].toString().trim() === "",
+	);
+
+	if (targetRowIndex === -1) {
+		// If no blank row found in the existing range, append after the last row
+		targetRowIndex = rows.length;
+	}
+
+	const nameIndex = 0;
+	const idIndex = headers.indexOf("Client ID");
+	const forIndex = headers.indexOf("For");
+	const primaryPayerIndex = headers.indexOf("Primary Payer");
+
+	if (idIndex === -1 || forIndex === -1 || primaryPayerIndex === -1) {
+		throw new Error(
+			"Required columns (Client ID, For, Primary Payer) not found in Punchlist",
+		);
+	}
+
+	const updateRequests: sheets_v4.Schema$ValueRange[] = [];
+
+	const rowNumber = targetRowIndex + 2; // +1 for 0-index, +1 for header row
+
+	updateRequests.push({
+		range: `${String.fromCharCode(65 + nameIndex)}${rowNumber}`,
+		values: [[client.fullName]],
+	});
+	updateRequests.push({
+		range: `${String.fromCharCode(65 + idIndex)}${rowNumber}`,
+		values: [[client.id.toString()]],
+	});
+	updateRequests.push({
+		range: `${String.fromCharCode(65 + forIndex)}${rowNumber}`,
+		values: [[client.asdAdhd ?? ""]],
+	});
+	updateRequests.push({
+		range: `${String.fromCharCode(65 + primaryPayerIndex)}${rowNumber}`,
+		values: [[client.primaryPayer ?? ""]],
+	});
+
+	await sheetsApi.spreadsheets.values.batchUpdate({
+		spreadsheetId: PUNCHLIST_ID,
+		requestBody: {
+			valueInputOption: "USER_ENTERED",
+			data: updateRequests,
+		},
+	});
+
+	return true;
+};
+
 export const getMissingFromPunchlistData = async (session: Session) => {
 	const punchClients = await getPunchData(session);
 	const punchClientIds = new Set(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -60,6 +60,7 @@ export const permissionPresets = [
 			"clients:shell",
 			"clients:merge",
 			"clients:asdadhd",
+			"clients:email",
 			"clients:questionnaires:create",
 			"clients:questionnaires:createexternal",
 			"settings:evaluators",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -35,22 +35,28 @@ export function formatError(message: string): string {
 	return formattedMessage;
 }
 
+export const getInsuranceShortName = (
+	officialName: string | null,
+	insurances: InsuranceWithAliases[],
+) => {
+	if (!officialName) return null;
+	const insurance = insurances.find(
+		(i) =>
+			i.shortName === officialName ||
+			i.aliases.some((a) => a.name === officialName),
+	);
+	return insurance?.shortName || officialName;
+};
+
 export const mapInsuranceToShortNames = (
 	primary: string | null,
 	secondary: string | null,
 	insurances: InsuranceWithAliases[],
 ) => {
-	const getShortName = (officialName: string | null) => {
-		if (!officialName) return null;
-		const insurance = insurances.find(
-			(i) =>
-				i.shortName === officialName ||
-				i.aliases.some((a) => a.name === officialName),
-		);
-		return insurance?.shortName || officialName;
-	};
-
-	return [getShortName(primary), getShortName(secondary)]
+	return [
+		getInsuranceShortName(primary, insurances),
+		getInsuranceShortName(secondary, insurances),
+	]
 		.filter(Boolean)
 		.join(" | ");
 };

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -110,3 +110,10 @@ export const pythonConfigSchema = z.object({
 });
 
 export type pythonConfig = z.infer<typeof pythonConfigSchema>;
+
+export const referralDataSchema = z.object({
+	schoolIepStatus: z.string().optional(),
+	schoolExplanation: z.string().optional(),
+	otherNotes: z.string().optional(),
+	locationPreference: z.string().optional(),
+});

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -116,4 +116,7 @@ export const referralDataSchema = z.object({
 	schoolExplanation: z.string().optional(),
 	otherNotes: z.string().optional(),
 	locationPreference: z.string().optional(),
+	needsReachOut: z.enum(["reach_out", "review"]).nullable().optional(),
+	reachOutCompleted: z.boolean().optional(),
+	email: z.string().optional(),
 });

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -112,6 +112,7 @@ export const pythonConfigSchema = z.object({
 export type pythonConfig = z.infer<typeof pythonConfigSchema>;
 
 export const referralDataSchema = z.object({
+	notes: z.string().optional(),
 	schoolIepStatus: z.string().optional(),
 	schoolExplanation: z.string().optional(),
 	otherNotes: z.string().optional(),

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -120,4 +120,5 @@ export const referralDataSchema = z.object({
 	needsReachOut: z.enum(["reach_out", "review"]).nullable().optional(),
 	reachOutCompleted: z.boolean().optional(),
 	email: z.string().optional(),
+	followedByBabyNet: z.enum(["yes", "no"]).nullable().optional(),
 });

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -113,7 +113,6 @@ export type pythonConfig = z.infer<typeof pythonConfigSchema>;
 
 export const referralDataSchema = z.object({
 	notes: z.string().optional(),
-	schoolIepStatus: z.string().optional(),
 	schoolExplanation: z.string().optional(),
 	otherNotes: z.string().optional(),
 	locationPreference: z.string().optional(),

--- a/src/server/api/routers/client.ts
+++ b/src/server/api/routers/client.ts
@@ -21,9 +21,15 @@ import {
 import { distance as levDistance } from "fastest-levenshtein";
 import { z } from "zod";
 import { CLIENT_COLOR_KEYS } from "~/lib/colors";
-import { renameDriveFolder, syncPunchData } from "~/lib/google";
+import { ALLOWED_ASD_ADHD_VALUES } from "~/lib/constants";
+import {
+	renameDriveFolder,
+	syncPunchData,
+	updatePunchData,
+} from "~/lib/google";
 import type { ClientWithIssueInfo } from "~/lib/models";
 import { getDistanceSQL, isShellClientId } from "~/lib/utils";
+import { referralDataSchema } from "~/lib/validations";
 import {
 	assertPermission,
 	createTRPCRouter,
@@ -760,6 +766,9 @@ export const clientRouter = createTRPCRouter({
 				recordsNeeded: z.enum(["Needed", "Not Needed"]).optional(),
 				babyNetERNeeded: z.boolean().optional(),
 				babyNetERDownloaded: z.boolean().optional(),
+				asdAdhd: z.enum(ALLOWED_ASD_ADHD_VALUES).optional(),
+				referralData: referralDataSchema.optional(),
+				email: z.string().optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -826,6 +835,13 @@ export const clientRouter = createTRPCRouter({
 				input.babyNetERDownloaded !== currentClient.babyNetERDownloaded
 					? (["clients:records:babynet"] as const)
 					: []),
+				...(input.asdAdhd !== undefined &&
+				input.asdAdhd !== currentClient.asdAdhd
+					? (["clients:asdadhd"] as const)
+					: []),
+				...(input.email !== undefined && input.email !== currentClient.email
+					? (["clients:email"] as const)
+					: []),
 			];
 
 			if (permissionsToCheck.length > 0) {
@@ -847,6 +863,9 @@ export const clientRouter = createTRPCRouter({
 				recordsNeeded?: "Needed" | "Not Needed";
 				babyNetERNeeded?: boolean;
 				babyNetERDownloaded?: boolean;
+				asdAdhd?: (typeof ALLOWED_ASD_ADHD_VALUES)[number];
+				referralData?: z.infer<typeof referralDataSchema>;
+				email?: string;
 			} = {};
 
 			if (input.color !== undefined) {
@@ -898,6 +917,28 @@ export const clientRouter = createTRPCRouter({
 			}
 			if (input.babyNetERDownloaded !== undefined) {
 				updateData.babyNetERDownloaded = input.babyNetERDownloaded;
+			}
+			if (input.asdAdhd !== undefined) {
+				updateData.asdAdhd = input.asdAdhd;
+
+				if (ctx.session.user.accessToken && ctx.session.user.refreshToken) {
+					try {
+						await updatePunchData(ctx.session, input.clientId.toString(), {
+							asdAdhd: input.asdAdhd,
+						});
+					} catch (e) {
+						ctx.logger.error(
+							e,
+							`Failed to update punchlist for client ${input.clientId}. This is normal if they are not on the punchlist.`,
+						);
+					}
+				}
+			}
+			if (input.referralData !== undefined) {
+				updateData.referralData = input.referralData;
+			}
+			if (input.email !== undefined) {
+				updateData.email = input.email;
 			}
 
 			await ctx.db

--- a/src/server/api/routers/client.ts
+++ b/src/server/api/routers/client.ts
@@ -641,7 +641,6 @@ export const clientRouter = createTRPCRouter({
 	}),
 
 	getNeedsReachOut: protectedProcedure.query(async ({ ctx }) => {
-		assertPermission(ctx.session.user, "clients:reachout");
 		const results = await ctx.db.query.clients.findMany({
 			where: and(
 				eq(clients.status, true),
@@ -654,7 +653,6 @@ export const clientRouter = createTRPCRouter({
 	}),
 
 	getNeedsReview: protectedProcedure.query(async ({ ctx }) => {
-		assertPermission(ctx.session.user, "clients:reviewreachout");
 		const results = await ctx.db.query.clients.findMany({
 			where: and(
 				eq(clients.status, true),

--- a/src/server/api/routers/client.ts
+++ b/src/server/api/routers/client.ts
@@ -866,14 +866,26 @@ export const clientRouter = createTRPCRouter({
 				...(input.email !== undefined && input.email !== currentClient.email
 					? (["clients:email"] as const)
 					: []),
-				...(input.referralData?.needsReachOut !== undefined &&
-				input.referralData.needsReachOut !==
-					currentClient.referralData?.needsReachOut
-					? input.referralData.needsReachOut === "reach_out" ||
-						(input.referralData.needsReachOut === null &&
-							currentClient.referralData?.needsReachOut === "reach_out")
-						? (["clients:reachout"] as const)
-						: (["clients:reviewreachout"] as const)
+				...(input.referralData !== undefined &&
+				JSON.stringify(input.referralData) !==
+					JSON.stringify(currentClient.referralData)
+					? (() => {
+							const current = currentClient.referralData ?? {};
+							const updates = input.referralData;
+
+							// Check if reach_out status is being changed
+							const reachOutChanged =
+								updates.needsReachOut !== current.needsReachOut &&
+								(updates.needsReachOut === "reach_out" ||
+									(updates.needsReachOut === null &&
+										current.needsReachOut === "reach_out"));
+
+							if (reachOutChanged) {
+								return ["clients:referral:infobox"] as const;
+							}
+
+							return ["clients:referral:fillout"] as const;
+						})()
 					: []),
 			];
 

--- a/src/server/api/routers/client.ts
+++ b/src/server/api/routers/client.ts
@@ -640,6 +640,32 @@ export const clientRouter = createTRPCRouter({
 		return clientsWithoutRecordsNeeded;
 	}),
 
+	getNeedsReachOut: protectedProcedure.query(async ({ ctx }) => {
+		assertPermission(ctx.session.user, "clients:reachout");
+		const results = await ctx.db.query.clients.findMany({
+			where: and(
+				eq(clients.status, true),
+				sql`JSON_EXTRACT(${clients.referralData}, '$.needsReachOut') = 'reach_out'`,
+			),
+			orderBy: desc(clients.addedDate),
+		});
+
+		return results;
+	}),
+
+	getNeedsReview: protectedProcedure.query(async ({ ctx }) => {
+		assertPermission(ctx.session.user, "clients:reviewreachout");
+		const results = await ctx.db.query.clients.findMany({
+			where: and(
+				eq(clients.status, true),
+				sql`JSON_EXTRACT(${clients.referralData}, '$.needsReachOut') = 'review'`,
+			),
+			orderBy: desc(clients.addedDate),
+		});
+
+		return results;
+	}),
+
 	getUnreviewedRecords: protectedProcedure.query(async ({ ctx }) => {
 		const threeWeekdaysAgo = subBusinessDays(new Date(), 3);
 
@@ -841,6 +867,15 @@ export const clientRouter = createTRPCRouter({
 					: []),
 				...(input.email !== undefined && input.email !== currentClient.email
 					? (["clients:email"] as const)
+					: []),
+				...(input.referralData?.needsReachOut !== undefined &&
+				input.referralData.needsReachOut !==
+					currentClient.referralData?.needsReachOut
+					? input.referralData.needsReachOut === "reach_out" ||
+						(input.referralData.needsReachOut === null &&
+							currentClient.referralData?.needsReachOut === "reach_out")
+						? (["clients:reachout"] as const)
+						: (["clients:reviewreachout"] as const)
 					: []),
 			];
 

--- a/src/server/api/routers/google.ts
+++ b/src/server/api/routers/google.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { distance as levDistance } from "fastest-levenshtein";
 import z from "zod";
@@ -7,9 +8,11 @@ import {
 	findDuplicateIdFolders,
 	getMissingFromPunchlistData,
 	getPunchData,
+	pushToPunch,
 	renameDriveFolder,
 	updatePunchData,
 } from "~/lib/google";
+import { getInsuranceShortName } from "~/lib/utils";
 import type { Client } from "~/lib/models";
 import {
 	assertPermission,
@@ -217,15 +220,9 @@ export const googleRouter = createTRPCRouter({
 					CACHE_KEY_MISSING_PUNCHLIST,
 				);
 			} catch (error) {
-				console.error(
-					"Error updating ASD/ADHD status in Google Sheets:",
+				ctx.logger.error(
 					error,
-				);
-
-				throw new Error(
-					`Failed to update ASD/ADHD status in Google Sheets: ${
-						error instanceof Error ? error.message : "Unknown error"
-					}`,
+					`Failed to update ASD/ADHD status in Google Sheets for client ${input.clientId}. This is normal if they are not on the punchlist.`,
 				);
 			}
 
@@ -447,4 +444,55 @@ export const googleRouter = createTRPCRouter({
 			missingClients,
 		};
 	}),
+
+	pushToPunch: protectedProcedure
+		.input(z.number())
+		.mutation(async ({ ctx, input }) => {
+			if (!ctx.session.user.accessToken || !ctx.session.user.refreshToken) {
+				throw new Error("No access token or refresh token");
+			}
+
+			const client = await ctx.db.query.clients.findFirst({
+				where: eq(clients.id, input),
+			});
+
+			if (!client) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Client not found",
+				});
+			}
+
+			const allInsurances = await ctx.db.query.insurances.findMany({
+				with: {
+					aliases: true,
+				},
+			});
+
+			const primaryInsurance = getInsuranceShortName(
+				client.primaryInsurance,
+				allInsurances,
+			);
+
+			ctx.logger.info({ clientId: client.id }, "Pushing client to Punchlist");
+
+			try {
+				await pushToPunch(ctx.session, {
+					id: client.id,
+					fullName: client.fullName,
+					asdAdhd: client.asdAdhd,
+					primaryPayer: primaryInsurance,
+				});
+
+				await invalidateCache(ctx, "google:sheets:punchlist");
+
+				return { success: true, message: "Pushed to Punchlist successfully" };
+			} catch (error) {
+				ctx.logger.error(error, "Failed to push to Punchlist");
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: `Failed to push to Punchlist: ${error instanceof Error ? error.message : "Unknown error"}`,
+				});
+			}
+		}),
 });

--- a/src/server/api/routers/google.ts
+++ b/src/server/api/routers/google.ts
@@ -546,14 +546,14 @@ export const googleRouter = createTRPCRouter({
 	getPushPreview: protectedProcedure
 		.input(z.number())
 		.query(async ({ ctx, input }) => {
-			assertPermission(ctx.session.user, "clients:pushtopunch");
+			assertPermission(ctx.session.user, "clients:referral:pushtopunch");
 			return getPreviewData(ctx, input);
 		}),
 
 	pushToPunch: protectedProcedure
 		.input(z.number())
 		.mutation(async ({ ctx, input }) => {
-			assertPermission(ctx.session.user, "clients:pushtopunch");
+			assertPermission(ctx.session.user, "clients:referral:pushtopunch");
 			if (!ctx.session.user.accessToken || !ctx.session.user.refreshToken) {
 				throw new Error("No access token or refresh token");
 			}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -10,7 +10,7 @@ import type z from "zod";
 import { CLIENT_COLOR_KEYS } from "~/lib/colors";
 import { QUESTIONNAIRE_STATUSES } from "~/lib/constants";
 import type { PermissionsObject } from "~/lib/types";
-import type { pythonConfigSchema } from "~/lib/validations";
+import type { pythonConfigSchema, referralDataSchema } from "~/lib/validations";
 
 /**
  * @see https://orm.drizzle.team/docs/goodies#multi-project-schema
@@ -263,6 +263,9 @@ export const clients = createTable(
 		recordsNeeded: d.mysqlEnum("recordsNeeded", ["Needed", "Not Needed"]),
 		babyNetERNeeded: d.boolean().notNull().default(false),
 		babyNetERDownloaded: d.boolean().notNull().default(false),
+		referralData: d
+			.json("referralData")
+			.$type<z.infer<typeof referralDataSchema>>(),
 	}),
 	(t) => [
 		index("hash_idx").on(t.hash),


### PR DESCRIPTION
- **feat: add referral tab**
- **fix: referral wording from meeting**
- **feat: don't show school question based on age**
- **feat: add alert that referral tab should not be used for babynet**
- **feat: add lists for reach out, add push to punch data and preview**
- **feat: add copy message button to referral tab**
- **feat: add another link to therapyappointment profile**
- **fix: update wording, only display school records request when under 20**
- **feat: add another notes box to referral tab**
- **feat: add truncated client header to referral tab**
- **feat: add followed by babynet question, explicit instructions to read script out loud**
- **feat: remove explicit instructions to speak each section, color ta message section**
- **fix: user doesn't need special permissions to see which clients need reach out and review**
- **feat: replace iep question with charter school question**
- **feat: move referral section on dashboard**
- **feat: permissions for referral tab**
